### PR TITLE
Traducir interfaz al español y agregar guía

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,7 +52,7 @@ def check_scam():
         if existing_text:
             scam_detected = True
 
-    result_message = "Potential scam detected!" if scam_detected else "This looks safe."
+    result_message = "Posible estafa detectada!" if scam_detected else "Todo parece seguro."
 
     # Persist the submitted message to the database
     new_msg = Message(phone_number=phone_number, text_message=text_message)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,29 +1,30 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Scam Message Checker</title>
+    <title>Detector de Estafas</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
     <div class="container">
-        <h1>Scam Message Checker</h1>
+        <h1>Detector de Estafas</h1>
 
         <form action="{{ url_for('check_scam') }}" method="POST">
             <div>
-                <label for="phone_number">Phone Number:</label>
+                <label for="phone_number">Número de teléfono:</label>
                 <input type="number" id="phone_number" name="phone_number" value="{{ previous_phone_number if previous_phone_number is not none else '' }}">
             </div>
             <br>
             <div>
-                <label for="text_message">Message:</label>
+                <label for="text_message">Mensaje:</label>
                 <textarea id="text_message" name="text_message" rows="4" cols="50">{{ previous_text_message if previous_text_message is not none else '' }}</textarea>
             </div>
             <br>
             <div>
-                <button type="submit">Check Message</button>
+                <button type="submit">Verificar mensaje</button>
             </div>
+            <p class="info">Esta herramienta compara el número y el mensaje ingresados con reportes previos de estafas para indicarte si es sospechoso.</p>
         </form>
 
         {% if result_message %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -29,7 +29,7 @@ class TestScamApp(unittest.TestCase):
     def test_index_page_loads(self):
         response = self.client.get('/')
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Scam Message Checker", response.data)
+        self.assertIn(b"Detector de Estafas", response.data)
 
     def test_safe_submission_new_number_new_message(self):
         response = self.client.post('/check_scam', data={
@@ -37,7 +37,7 @@ class TestScamApp(unittest.TestCase):
             'text_message': 'Hello this is a test'
         })
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"This looks safe.", response.data)
+        self.assertIn(b"Todo parece seguro.", response.data)
         with main_app.app.app_context():
             msg = Message.query.filter_by(phone_number=1234567890).first()
             self.assertIsNotNone(msg)
@@ -52,7 +52,7 @@ class TestScamApp(unittest.TestCase):
             'text_message': 'A new message for a known number'
         })
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Potential scam detected!", response.data)
+        self.assertIn(b"Posible estafa detectada!", response.data)
         with main_app.app.app_context():
             msgs = Message.query.filter_by(phone_number=1112223333).all()
             self.assertEqual(len(msgs), 2)
@@ -66,7 +66,7 @@ class TestScamApp(unittest.TestCase):
             'text_message': 'This is a known scam message'
         })
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Potential scam detected!", response.data)
+        self.assertIn(b"Posible estafa detectada!", response.data)
         with main_app.app.app_context():
             msgs = Message.query.filter_by(text_message='This is a known scam message').all()
             self.assertEqual(len(msgs), 2)
@@ -77,7 +77,7 @@ class TestScamApp(unittest.TestCase):
             'text_message': ''
         })
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"This looks safe.", response.data)
+        self.assertIn(b"Todo parece seguro.", response.data)
         with main_app.app.app_context():
             msg = Message.query.filter_by(phone_number=5555555555).first()
             self.assertIsNotNone(msg)
@@ -89,7 +89,7 @@ class TestScamApp(unittest.TestCase):
             'text_message': 'Just a message, no number'
         })
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"This looks safe.", response.data)
+        self.assertIn(b"Todo parece seguro.", response.data)
         with main_app.app.app_context():
             msg = Message.query.filter_by(text_message='Just a message, no number').first()
             self.assertIsNotNone(msg)
@@ -104,7 +104,7 @@ class TestScamApp(unittest.TestCase):
             'text_message': ''
         })
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Potential scam detected!", response.data)
+        self.assertIn(b"Posible estafa detectada!", response.data)
         with main_app.app.app_context():
             msgs = Message.query.filter_by(phone_number=7778889999).all()
             self.assertEqual(len(msgs), 2)
@@ -118,7 +118,7 @@ class TestScamApp(unittest.TestCase):
             'text_message': 'Secret scam phrase alone'
         })
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Potential scam detected!", response.data)
+        self.assertIn(b"Posible estafa detectada!", response.data)
         with main_app.app.app_context():
             msgs = Message.query.filter_by(text_message='Secret scam phrase alone').all()
             self.assertEqual(len(msgs), 2)
@@ -129,7 +129,7 @@ class TestScamApp(unittest.TestCase):
             'text_message': ''
         })
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"This looks safe.", response.data)
+        self.assertIn(b"Todo parece seguro.", response.data)
         self.assertEqual(self._count_messages(), 1)
 
     def test_phone_number_with_spaces_gets_stripped_and_converted(self):
@@ -138,7 +138,7 @@ class TestScamApp(unittest.TestCase):
             'text_message': 'Test message with spaced number'
         })
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"This looks safe.", response.data)
+        self.assertIn(b"Todo parece seguro.", response.data)
         with main_app.app.app_context():
             msg = Message.query.filter_by(phone_number=123).first()
             self.assertIsNotNone(msg)
@@ -149,7 +149,7 @@ class TestScamApp(unittest.TestCase):
             'text_message': '  A message with spaces  '
         })
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"This looks safe.", response.data)
+        self.assertIn(b"Todo parece seguro.", response.data)
         with main_app.app.app_context():
             msg = Message.query.filter_by(phone_number=7890123456).first()
             self.assertEqual(msg.text_message, 'A message with spaces')


### PR DESCRIPTION
## Summary
- translate the web interface to Spanish
- show instructions below the button
- return results also in Spanish
- update tests for new Spanish messages

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a2a3999d483268989243ec8869636